### PR TITLE
Put fat jar handling into existing handler.

### DIFF
--- a/src/main/resources/META-INF/services/org.webjars.urlprotocols.UrlProtocolHandler
+++ b/src/main/resources/META-INF/services/org.webjars.urlprotocols.UrlProtocolHandler
@@ -1,3 +1,3 @@
-org.webjars.urlprotocols.FatJarUrlProtocolHandler
+#org.webjars.urlprotocols.FatJarUrlProtocolHandler
 org.webjars.urlprotocols.JarUrlProtocolHandler
 org.webjars.urlprotocols.FileUrlProtocolHandler


### PR DESCRIPTION
There are now two failing tests, which suggests that `partialJarPaths.length == 3` is not a sufficient check?

However, the tests create the JAR files programmatically, so I don't know how representative they are. They seem to have been created by @iamasoft, could you comment?
